### PR TITLE
Add more stubs to lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Mac OS specific
+.DS_Store

--- a/lib/meteor/cfs:base-package.js
+++ b/lib/meteor/cfs:base-package.js
@@ -1,0 +1,8 @@
+export const FS = {
+  Store: {
+    GridFS: jest.fn(),
+  },
+  Collection: jest.fn(() => ({
+    allow: jest.fn(),
+  })),
+};

--- a/lib/meteor/cfs:graphicsmagick.js
+++ b/lib/meteor/cfs:graphicsmagick.js
@@ -1,0 +1,1 @@
+export const gm = jest.fn();

--- a/lib/meteor/react-meteor-data.js
+++ b/lib/meteor/react-meteor-data.js
@@ -1,0 +1,3 @@
+const createContainer = jest.fn((options = {}, component) => component );
+
+export const withTracker = jest.fn(Op => jest.fn(C => createContainer(Op, C)));

--- a/lib/meteor/staringatlights:flow-router.js
+++ b/lib/meteor/staringatlights:flow-router.js
@@ -1,0 +1,3 @@
+export const FlowRouter = {
+  go: jest.fn(),
+};

--- a/lib/meteor/universe:i18n.js
+++ b/lib/meteor/universe:i18n.js
@@ -1,0 +1,7 @@
+const i18n = {
+  createComponent: jest.fn(),
+  createTranslator: jest.fn(),
+  __: jest.fn(),
+};
+
+export default i18n;


### PR DESCRIPTION
This is the package list I've used so far :
- cfs:base-package.js
- cfs:graphicsmagick.js
- react-meteor-data.js
- staringatlights:flow-router.js (works for every flow router forks)
- universe:i18n.js

Also added an exclusion for .DS_Store in .gitignore.

Thank you for your fork !