### PR TITLE
Mock Meteor.call() with implementation of Meteor.methods(...)

### DIFF
--- a/lib/meteor/meteor.js
+++ b/lib/meteor/meteor.js
@@ -1,4 +1,4 @@
-import { Mongo } from 'meteor/mongo'
+const { Mongo } = require('./mongo');
 
 const Meteor = {
   isServer: true,

--- a/lib/meteor/meteor.js
+++ b/lib/meteor/meteor.js
@@ -1,13 +1,30 @@
-const { Mongo } = require('./mongo');
+import { Mongo } from 'meteor/mongo'
 
 const Meteor = {
   isServer: true,
+  isClient: false,
   isTest: true,
   loginWithPassword: jest.fn(),
   loginWithFacebook: jest.fn(),
-  methods: jest.fn(),
-  call: jest.fn(),
+
+  __mocked_methods: {},
+  methods: jest.fn((methods) => {
+    let mocked_methods = {}
+    Object.keys(methods).forEach(key =>
+      mocked_methods[key] = jest.fn(methods[key])
+        .mockName('Meteor.call("'+key+'")')
+    )
+    Meteor.__mocked_methods = {...Meteor.__mocked_methods, ...mocked_methods}
+  }),
+  call: jest.fn((...args) => {
+    const name = args.shift()
+    if(!Meteor.__mocked_methods[name]) {
+      throw new Meteor.Error('Method '+name+' missing')
+    }
+    Meteor.__mocked_methods[name].call(Meteor, ...args)
+  }),
   callPromise: jest.fn(),
+
   publish: jest.fn(),
   subscribe: jest.fn(),
   user: jest.fn(),

--- a/lib/meteor/meteor.js
+++ b/lib/meteor/meteor.js
@@ -2,6 +2,7 @@ const { Mongo } = require('./mongo');
 
 const Meteor = {
   isServer: true,
+  isTest: true,
   loginWithPassword: jest.fn(),
   loginWithFacebook: jest.fn(),
   methods: jest.fn(),

--- a/lib/meteor/mongo.js
+++ b/lib/meteor/mongo.js
@@ -22,6 +22,7 @@ Collection.prototype.after = {
 Collection.prototype._ensureIndex = jest.fn();
 Collection.prototype.rawCollection = jest.fn().mockImplementation(() => {
   return {
+      update: jest.fn(),
       distinct: jest.fn(),
       mapReduce: jest.fn()
   }


### PR DESCRIPTION
This mock will mock the ```Meteor.methods()``` calls:
```javascript
Meteor.methods({
  'method_name'(arg1, arg2) {
    doSomething()
  }
})
```

The mock function can be collection from `Meteor.__mocked_methods` and the contents of the Meteor.method will be called:
```javascript
const mockFunc = Meteor.__mocked_methods['methods_name'];
Meteor.call('methods_name', arg1, arg2);
expect(mockFunc).toBeCalled()
expect(doSomething).toBeCalled()
```

[Running the implementation](https://github.com/arichter83/meteor-jest-stubs/blob/14590759ab36ffceb30abdb98547b78704901e17/lib/meteor/meteor.js#L24) is obviously a **breaking change** for many - it can be omitted by overriding:
```javascript
const mockFunc = Meteor.__mocked_methods['methods_name'];
mockFunc.mockImplementationOnce(() => {})
Meteor.call('methods_name', arg1, arg2);
expect(mockFunc).toBeCalled()
expect(doSomething).not.toBeCalled()
```