### PR TITLE
Update jest-cli peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/tomscholz/jest-meteor-stubs#readme",
   "peerDependencies": {
-    "jest-cli": "23.6.0"
+    "jest-cli": "^27.3.1"
   }
 }


### PR DESCRIPTION
Updating the jest-cli version due message `npm WARN meteor-jest-stubs@2.2.0 requires a peer of jest-cli@23.6.0 but none is installed. You must install peer dependencies yourself`.